### PR TITLE
feat: Reusable python functions to get/refresh Cognito tokens and get temporary AWS credentials by providing a Cognito ID token

### DIFF
--- a/code_samples/jupyter/get_and_refresh_tokens/README.md
+++ b/code_samples/jupyter/get_and_refresh_tokens/README.md
@@ -1,0 +1,22 @@
+# Python Function to Get and Refresh Cognito Tokens
+
+The source code for the function is available with the function_to_refresh_cognito_tokens.ipynb included 
+with this README file.
+
+The get_unity_cognito_access_token() function returns the Cognito access token. If the Cognito 
+access token is expired, then this function uses the Cognito refresh token to refresh the environment 
+variables: UNITY_COGNITO_ACCESS_TOKEN, UNITY_COGNITO_ID_TOKEN and UNITY_COGNITO_ACCESS_TOKEN_EXPIRY.
+After renewing the environment variables, this function returns the new Cognito access token.
+
+The environment variables UNITY_COGNITO_ACCESS_TOKEN_EXPIRY, UNITY_COGNITO_REFRESH_TOKEN, 
+UNITY_COGNITO_SECRET_HASH, UNITY_COGNITO_APP_CLIENT_ID and  UNITY_COGNITO_ACCESS_TOKEN should be 
+available for this function to work. These environment variables are populated during the JupyterLab spawn.
+
+This function uses the Cognito refresh token and by default the Cognito refresh token will expire after 30 days. 
+It was assumed that this JupyterLab will not stay active for more than 30 days. If this assumption is 
+no longer valid in the future, it is required to update this function to update the environment 
+variable REFRESH_TOKEN_AUTH too using the client_idp.initiate_auth with USER_PASSWORD_AUTH auth flow, after 30 days. 
+
+The following link contains an example where username and password is obtained from a user to execute 
+the client_idp.initiate_auth with USER_PASSWORD_AUTH auth flow.
+https://github.com/unity-sds/unity-cs-security/blob/main/code_samples/jupyter/identity_pool_aws_creds/Cognito-Identity-Pool-S3-Access.ipynb

--- a/code_samples/jupyter/get_and_refresh_tokens/Refresh-Cognito-Tokens.ipynb
+++ b/code_samples/jupyter/get_and_refresh_tokens/Refresh-Cognito-Tokens.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c771123e-932a-402d-9e29-517542c347ee",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pip install boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "726315ff-c00d-40fd-baf8-8bf7240fd032",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "import boto3\n",
+    "import json\n",
+    "\n",
+    "def get_unity_cognito_access_token():\n",
+    "    \n",
+    "    \"\"\"\n",
+    "    Returns the Cognito access token. If the Cognito access token is expired, then this function uses the Cognito refresh token\n",
+    "    to refresh the environment variables: UNITY_COGNITO_ACCESS_TOKEN, UNITY_COGNITO_ID_TOKEN and UNITY_COGNITO_ACCESS_TOKEN_EXPIRY. \n",
+    "    After renewing the environment variables, this fucntions returns the new Cognito access token.\n",
+    "    \n",
+    "    The environment variables UNITY_COGNITO_ACCESS_TOKEN_EXPIRY, UNITY_COGNITO_REFRESH_TOKEN, UNITY_COGNITO_SECRET_HASH, \n",
+    "    UNITY_COGNITO_APP_CLIENT_ID and  UNITY_COGNITO_ACCESS_TOKEN should be available for this function to work. These environment variables\n",
+    "    are populated during the JupyterLab spawn.\n",
+    "    \n",
+    "    This function uses the Cognito refresh token and by default the Cognito refresh token will expire after 30 days. It was assumed that this JupyterLab\n",
+    "    will not stay active more more than 30 days. If this assumption is no longer valid in future, it is required to update this fucntion to update the environment \n",
+    "    variable REFRESH_TOKEN_AUTH too using the client_idp.initiate_auth with USER_PASSWORD_AUTH auth flow. \n",
+    "    \n",
+    "    The following link contains an example where user name and password is obtained from a user to execute the client_idp.initiate_auth with USER_PASSWORD_AUTH auth flow.\n",
+    "    https://github.com/unity-sds/unity-cs-security/blob/main/code_samples/jupyter/identity_pool_aws_creds/Cognito-Identity-Pool-S3-Access.ipynb\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    unity_cognito_access_token_expiry = int(os.environ.get('UNITY_COGNITO_ACCESS_TOKEN_EXPIRY'))\n",
+    "    current_epoch_seconds = int(time.time())\n",
+    "\n",
+    "    # Check if the Cognito access token is expired\n",
+    "    if current_epoch_seconds > unity_cognito_access_token_expiry:\n",
+    "        # Get a new token\n",
+    "        client = boto3.client('cognito-idp', region_name='us-west-2')\n",
+    "\n",
+    "        # Get tokens from Cognito using the refresh token\n",
+    "        response = client.initiate_auth(\n",
+    "            AuthFlow='REFRESH_TOKEN_AUTH',\n",
+    "            AuthParameters={\n",
+    "                'REFRESH_TOKEN': os.environ.get('UNITY_COGNITO_REFRESH_TOKEN'),\n",
+    "                'SECRET_HASH': os.environ.get('UNITY_COGNITO_SECRET_HASH')\n",
+    "            },\n",
+    "            ClientId = os.environ.get('UNITY_COGNITO_APP_CLIENT_ID')\n",
+    "        )\n",
+    "\n",
+    "        access_token = response['AuthenticationResult']['AccessToken']\n",
+    "        id_token = response['AuthenticationResult']['IdToken']\n",
+    "        access_token_expiry = current_epoch_seconds + int(response['AuthenticationResult']['ExpiresIn'])\n",
+    "\n",
+    "        os.environ[\"UNITY_COGNITO_ACCESS_TOKEN\"] = str(access_token)\n",
+    "        os.environ[\"UNITY_COGNITO_ID_TOKEN\"] = str(id_token)\n",
+    "        os.environ[\"UNITY_COGNITO_ACCESS_TOKEN_EXPIRY\"] = str(access_token_expiry)\n",
+    "        \n",
+    "    return os.environ.get('UNITY_COGNITO_ACCESS_TOKEN')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "566ec32b-a48e-423e-82cf-d38ae348ffc8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(get_unity_cognito_access_token())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/code_samples/jupyter/identity_pool_aws_creds/Get-AWS-Creds-From-Cognito-ID-Token.ipynb
+++ b/code_samples/jupyter/identity_pool_aws_creds/Get-AWS-Creds-From-Cognito-ID-Token.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bb3b2b3-85d6-4237-8e93-4940fb5bdcac",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pip install boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90135de7-f963-4708-9ade-9481c515f0a9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import json\n",
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "# Set constants\n",
+    "\n",
+    "# Obtain the Cognito identity pool ID from the Unity Common Services Team\n",
+    "IDENTITY_POOL_ID = '<IDENTITY_POOL_ID>'\n",
+    "\n",
+    "# You AWS Account ID\n",
+    "AWS_ACCOUNT_ID = '<AWS_ACCOUNT_ID>'\n",
+    "\n",
+    "# Obtain the Cognito user pool ID from the Unity Common Services Team\n",
+    "COGNITO_USER_POOL_ID = '<COGNITO_USER_POOL_ID>'\n",
+    "\n",
+    "# Obtain the Cognito Client ID relevant to your usecase from the Unity Common Services Team\n",
+    "COGNITO_CLIENT_ID = '<COGNITO_CLIENT_ID>'\n",
+    "\n",
+    "# AWS Region\n",
+    "REGION = 'us-west-2'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e51b3a8b-539f-4946-a09b-8f215ea7bea1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "'''\n",
+    "The following code obtained an ID token using the USER_PASSWORD_AUTH auth flow of client_idp.initiate_auth(). This code interactively requests for\n",
+    "username and password to obtain the ID token. This code is only added for demonstration purposes and usually the Cognito ID token should be available \n",
+    "as the UNITY_COGNITO_ID_TOKEN environment variable, which is stored during the JupyterLab spawn or an access token refresh.\n",
+    "\n",
+    "'''\n",
+    "\n",
+    "# Create Cognito IDP client\n",
+    "client_idp = boto3.client('cognito-idp', region_name=REGION)\n",
+    " \n",
+    "# Promt the user to enter the username and password\n",
+    "username = input('Enter your Cognito username: ')\n",
+    "password = getpass.getpass('Enter your Cognito password: ')\n",
+    "auth_params = {\n",
+    "    \"USERNAME\" : username,\n",
+    "    \"PASSWORD\" : password\n",
+    "}\n",
+    "\n",
+    "# Get tokens from Cognito\n",
+    "response = client_idp.initiate_auth(\n",
+    "    AuthFlow = 'USER_PASSWORD_AUTH',\n",
+    "    AuthParameters = auth_params,\n",
+    "    ClientId = COGNITO_CLIENT_ID\n",
+    ")\n",
+    "\n",
+    "# Read ID token\n",
+    "id_token = response['AuthenticationResult']['IdToken']\n",
+    "print('ID Token = ' + id_token)\n",
+    "os.environ[\"UNITY_COGNITO_ID_TOKEN\"] = str(id_token)\n",
+    "\n",
+    "        \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80a43800-6634-4c62-9c22-bb852ea8d15e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def get_aws_creds_from_cognito_id_token(cognito_identity_pool_id, cognito_user_pool_id, aws_account_id, region, cognito_id_token):\n",
+    "    \n",
+    "    '''\n",
+    "    Stores AWS Access Key ID, Secret Key and Session Token as environment variables UNITY_AWS_ACCESS_KEY_ID, UNITY_AWS_SECRET_ACCESS_KEY and UNITY_AWS_SESSION_TOKEN.\n",
+    "    \n",
+    "    The following parameters should be provided:\n",
+    "    \n",
+    "    Parameter cognito_identity_pool_id: Obtain the Cognito identity pool ID from the Unity Common Services Team\n",
+    "    Parameter cognito_user_pool_id: Obtain the Cognito user pool ID from the Unity Common Services Team\n",
+    "    Parameter aws_account_id: AWS Account ID\n",
+    "    Parameter region: AWS region\n",
+    "    Parameter cognito_id_token: The =Cognito ID token (stored as environment variable UNITY_COGNITO_ID_TOKEN as a result of a previous step/process)\n",
+    "\n",
+    "    \n",
+    "    '''\n",
+    "    \n",
+    "    # Create Cognito Identity client\n",
+    "    client_identify = boto3.client('cognito-identity', region_name = REGION)\n",
+    "\n",
+    "    id_token = os.environ.get('UNITY_COGNITO_ID_TOKEN')\n",
+    "\n",
+    "    # Get Identify ID\n",
+    "    response_identity_get_id = client_identify.get_id(\n",
+    "                AccountId = AWS_ACCOUNT_ID,\n",
+    "                IdentityPoolId = IDENTITY_POOL_ID,\n",
+    "                Logins = {\n",
+    "                    'cognito-idp.us-west-2.amazonaws.com/' + COGNITO_USER_POOL_ID : id_token\n",
+    "                }\n",
+    "    ) \n",
+    "    IDENTITY_ID = response_identity_get_id['IdentityId']                                                                     \n",
+    "\n",
+    "\n",
+    "    # Get temporary AWS credentials for the identity    \n",
+    "    aws_credentials = client_identify.get_credentials_for_identity(\n",
+    "        IdentityId = IDENTITY_ID,\n",
+    "        Logins = {\n",
+    "            'cognito-idp.us-west-2.amazonaws.com/' + COGNITO_USER_POOL_ID : id_token\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "    access_key_id = aws_credentials['Credentials']['AccessKeyId']\n",
+    "    secret_key = aws_credentials['Credentials']['SecretKey']\n",
+    "    session_token = aws_credentials['Credentials']['SessionToken']\n",
+    "\n",
+    "    os.environ[\"UNITY_AWS_ACCESS_KEY_ID\"] = str(access_key_id)\n",
+    "    os.environ[\"UNITY_AWS_SECRET_ACCESS_KEY\"] = str(secret_key)\n",
+    "    os.environ[\"UNITY_AWS_SESSION_TOKEN\"] = str(session_token)\n",
+    "    \n",
+    "    print('Temporary AWS Credentials are stored as environment variables: UNITY_AWS_ACCESS_KEY_ID, UNITY_AWS_SECRET_ACCESS_KEY and UNITY_AWS_SESSION_TOKEN')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54d24607-6203-4b50-9eec-19d2b6d5d5dc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "id_token = os.environ.get('UNITY_COGNITO_ID_TOKEN')\n",
+    "get_aws_creds_from_cognito_id_token(IDENTITY_POOL_ID, COGNITO_USER_POOL_ID, AWS_ACCOUNT_ID, REGION, id_token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9f6a455-4040-4a89-ba24-d10e3fb877b9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(os.environ.get('UNITY_AWS_ACCESS_KEY_ID'))\n",
+    "print(os.environ.get('UNITY_AWS_SECRET_ACCESS_KEY'))\n",
+    "print(os.environ.get('UNITY_AWS_SESSION_TOKEN'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2434f16-c66a-4f5c-9305-2f54efd305fd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Create an S3 client\n",
+    "s3_client = boto3.client('s3', \n",
+    "                      aws_access_key_id = os.environ.get('UNITY_AWS_ACCESS_KEY_ID'),\n",
+    "                      aws_secret_access_key = os.environ.get('UNITY_AWS_SECRET_ACCESS_KEY'),\n",
+    "                      aws_session_token = os.environ.get('UNITY_AWS_SESSION_TOKEN')\n",
+    "                      )\n",
+    "    \n",
+    "s3_response = s3_client.list_buckets()\n",
+    "\n",
+    "# Print S3 bucket names\n",
+    "print('Existing buckets:')\n",
+    "for bucket in s3_response['Buckets']:\n",
+    "    print(f'  {bucket[\"Name\"]}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/code_samples/jupyter/identity_pool_aws_creds/README.md
+++ b/code_samples/jupyter/identity_pool_aws_creds/README.md
@@ -24,8 +24,13 @@ A Cognito identity pool should be created and associated with the IAM Role creat
 
 ## Jupyter Notebook on Jupyter Lab
 
+The Get-AWS-Creds-From-Cognito-ID-Token.ipynb Jupyter Notebook provides a python function called
+get_aws_creds_from_cognito_id_token(cognito_identity_pool_id, cognito_user_pool_id, aws_account_id, region, cognito_id_token).
+This function is used to obtain temporary AWS credentials using a Cognito ID token (check the Note below
+for more information).
+
 1) Login to JupyterHub to launch a JupyterLab 
-2) Upload the Cognito-Identity-Pool-S3-Access.ipynb
+2) Upload the Get-AWS-Creds-From-Cognito-ID-Token.ipynb
 3) Update the following constants
 ```
 # Obtain the Cognito identity pool ID from the Unity Common Services Team
@@ -46,3 +51,13 @@ REGION = 'us-west-2'
 4) Run -> Run All Cells
 5) Enter the Cognito username and password when prompted
 6) Observe the list of S3 buckets at the end of the Jupyter Notebook
+
+Note:
+
+In above Get-AWS-Creds-From-Cognito-ID-Token.ipynb Jupyter Notebook,an ID token is obtained using the 
+USER_PASSWORD_AUTH auth flow of client_idp.initiate_auth(). This code interactively requests for
+username and password to obtain the ID token. This code is only added for demonstration purposes and 
+usually the Cognito ID token should be available as the UNITY_COGNITO_ID_TOKEN environment variable, 
+which is stored during the JupyterLab spawn or an access token refresh. This UNITY_COGNITO_ID_TOKEN 
+environment variable can be updated using the get_unity_cognito_access_token() function defined in 
+the ../get_and_refresh_tokens/Refresh-Cognito-Tokens.ipynb


### PR DESCRIPTION
Reusable python functions to get/refresh Cognito tokens and get temporary AWS credentials by providing a Cognito ID token

Related to unity-cs #123
Related to unity-cs #122